### PR TITLE
Update node and alpine base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.15.1-alpine3.12 as js-builder
+FROM node:14.15.5-alpine3.13 as js-builder
 
 WORKDIR /usr/src/app/
 
@@ -32,7 +32,7 @@ COPY build.go package.json ./
 RUN go run build.go build
 
 # Final stage
-FROM alpine:3.12
+FROM alpine:3.13
 
 LABEL maintainer="Grafana team <hello@grafana.com>"
 


### PR DESCRIPTION
Update node image to 14.15.5-alpine3.13 and alpine to 3.13. This upgrade eliminates CVE-2022-37434.

Refs arrikto/dev#1976
Refs arrikto/rok#6395

Signed-off-by: Georgios Zaravinos <gezar@arrikto.com>

